### PR TITLE
WIP: Add Python 3.8 builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,11 +19,8 @@ environment:
   CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
-    - PYTHON: C:\Python27-x64
-      PYTHON_ARCH: "64"  # define this to download 64-bit FFTW dlls
-      PYTHON_VERSION: "2.7"  # used by run_with_env.cmd
-    - PYTHON: C:\Python35-x64
-      PYTHON_ARCH: "64"
+    - PYTHON: C:\Python35-x64  # define this to download 64-bit FFTW dlls
+      PYTHON_ARCH: "64"  # used by run_with_env.cmd
       PYTHON_VERSION: "3.5"
     - PYTHON: C:\Python36-x64
       PYTHON_ARCH: "64"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,11 +35,25 @@ environment:
       PYTHON_VERSION: "3.7"
       NP_BUILD_DEP: "numpy==1.14.5"
       NP_TEST_DEP: "numpy==1.14.5"
+    - PYTHON: C:\Python38-x64
+      PYTHON_ARCH: "64"
+      PYTHON_VERSION: "3.8"
+      NP_BUILD_DEP: "numpy==1.17.3"
+      NP_TEST_DEP: "numpy==1.17.3"
 
 init:
   - "ECHO \"%APPVEYOR_SCHEDULED_BUILD%\""
 
 install:
+
+  - echo "Installed SDKs:"
+  - dir "C:/Program Files/Microsoft SDKs/Windows"
+
+  # Get needed submodules
+  - git submodule update --init
+
+  # Install new Python if necessary
+  - ps: .\multibuild\install_python.ps1
 
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
@@ -50,10 +64,9 @@ install:
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
 
-  - python -m pip install -U pip
+  # Upgrade to the latest pip, setuptools, and wheel
+  - python -m pip install -U pip setuptools wheel
 
-  # Pin wheel to 0.26 to avoid Windows ABI tag for built wheel
-  - pip install wheel==0.26
   - dir %REPO_DIR%  # REPO_DIR should be empty prior to submodule update
   - git submodule update --init
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,8 +10,8 @@ environment:
   # Encrypted to matthew-brett account, for now.
   WHEELHOUSE_UPLOADER_SECRET:
     secure: 9s0gdDGnNnTt7hvyNpn0/ZzOMGPdwPp2SewFTfGzYk7uI+rdAN9rFq2D1gAP4NQh
-  NP_BUILD_DEP: "numpy==1.10.4"
-  NP_TEST_DEP: "numpy==1.10.4"
+  NP_BUILD_DEP: "numpy==1.13.3"
+  NP_TEST_DEP: "numpy==1.13.3"
 
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
@@ -25,8 +25,8 @@ environment:
     - PYTHON: C:\Python36-x64
       PYTHON_ARCH: "64"
       PYTHON_VERSION: "3.6"
-      NP_BUILD_DEP: "numpy==1.12"
-      NP_TEST_DEP: "numpy==1.12"
+      NP_BUILD_DEP: "numpy==1.13.3"
+      NP_TEST_DEP: "numpy==1.13.3"
     - PYTHON: C:\Python37-x64
       PYTHON_ARCH: "64"
       PYTHON_VERSION: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,6 @@ osx_image: xcode10.1
 matrix:
   include:
     - os: linux
-      env: MB_PYTHON_VERSION=2.7
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - UNICODE_WIDTH=16
-    - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
     - os: linux
@@ -49,10 +43,6 @@ matrix:
         - MB_PYTHON_VERSION=3.8
         - NP_BUILD_DEP=numpy==1.17.3
         - NP_TEST_DEP=numpy==1.17.3
-    - os: osx
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - MB_PYTHON_OSX_VER=10.9
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ env:
         - BUILD_COMMIT=v0.11.1
         - REPO_DIR=pyFFTW
         # pip dependencies to _build_ your project
-        - NP_BUILD_DEP="numpy==1.10.4"
+        - NP_BUILD_DEP="numpy==1.13.3"
         - CYTHON_BUILD_DEP="Cython"
         # pip dependencies to _test_ your project.  Include any dependencies
         # that you need, that are also specified in BUILD_DEPENDS, this will be
         # a separate install.
-        - NP_TEST_DEP="numpy==1.10.4"
+        - NP_TEST_DEP="numpy==1.13.3"
         - PLAT=x86_64
         - UNICODE_WIDTH=32
         - MANYLINUX_URL="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
@@ -31,8 +31,6 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
@@ -46,13 +44,11 @@ matrix:
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.5
-        - MB_PYTHON_OSX_VER=10.9
+        - MB_PYTHON_OSX_VER=10.6
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.6
         - MB_PYTHON_OSX_VER=10.9
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.7
@@ -67,8 +63,8 @@ matrix:
         - NP_TEST_DEP=numpy==1.17.3
 
 before_install:
-    - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP"
-    - TEST_DEPENDS="$NP_TEST_DEP"
+    - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP $SP_BUILD_DEP"
+    - TEST_DEPENDS="$NP_TEST_DEP $SP_TEST_DEP"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ language: generic
 sudo: required
 dist: trusty
 services: docker
-osx_image: xcode6.4
+osx_image: xcode10.1
 
 matrix:
   include:
@@ -44,22 +44,37 @@ matrix:
         - MB_PYTHON_VERSION=3.7
         - NP_BUILD_DEP=numpy==1.14.5
         - NP_TEST_DEP=numpy==1.14.5
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - NP_BUILD_DEP=numpy==1.17.3
+        - NP_TEST_DEP=numpy==1.17.3
     - os: osx
       env:
         - MB_PYTHON_VERSION=2.7
+        - MB_PYTHON_OSX_VER=10.9
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.5
+        - MB_PYTHON_OSX_VER=10.9
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.6
+        - MB_PYTHON_OSX_VER=10.9
         - NP_BUILD_DEP=numpy==1.11.3
         - NP_TEST_DEP=numpy==1.11.3
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.7
+        - MB_PYTHON_OSX_VER=10.9
         - NP_BUILD_DEP=numpy==1.14.5
         - NP_TEST_DEP=numpy==1.14.5
+    - os: osx
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - MB_PYTHON_OSX_VER=10.9
+        - NP_BUILD_DEP=numpy==1.17.3
+        - NP_TEST_DEP=numpy==1.17.3
 
 before_install:
     - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP"

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ https://travis-ci.org/pyFFTW/pyFFTW-wheels
 Appveyor interface at
 https://ci.appveyor.com/project/pyFFTW/pyFFTW-wheels
 The driving github repository is
-https://github.com/cancan101/pyFFTW-wheels
+https://github.com/pyFFTW/pyFFTW-wheels
 
 How it works
 ============


### PR DESCRIPTION
I recently made a release for PyWavelets supporting Python 3.8. I thought I would try applying similar changes here while I still recall what was needed.

Mainly, this PR updates `multibuild` to a newer commit that can install Python 3.8 for the user on Appveyor if needed.
