### PR TITLE
DO NOT MERGE: build python 2.7 wheels for v0.12.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 # Windows
 
 environment:
-  BUILD_COMMIT: v0.11.1
+  BUILD_COMMIT: v0.12.0
   REPO_DIR: pyFFTW
   PKG_NAME: pyFFTW
   WHEELHOUSE_UPLOADER_USERNAME: travis-worker
@@ -10,8 +10,8 @@ environment:
   # Encrypted to matthew-brett account, for now.
   WHEELHOUSE_UPLOADER_SECRET:
     secure: 9s0gdDGnNnTt7hvyNpn0/ZzOMGPdwPp2SewFTfGzYk7uI+rdAN9rFq2D1gAP4NQh
-  NP_BUILD_DEP: "numpy==1.10.4"
-  NP_TEST_DEP: "numpy==1.10.4"
+  NP_BUILD_DEP: "numpy==1.13.3"
+  NP_TEST_DEP: "numpy==1.13.3"
 
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
@@ -22,19 +22,6 @@ environment:
     - PYTHON: C:\Python27-x64
       PYTHON_ARCH: "64"  # define this to download 64-bit FFTW dlls
       PYTHON_VERSION: "2.7"  # used by run_with_env.cmd
-    - PYTHON: C:\Python35-x64
-      PYTHON_ARCH: "64"
-      PYTHON_VERSION: "3.5"
-    - PYTHON: C:\Python36-x64
-      PYTHON_ARCH: "64"
-      PYTHON_VERSION: "3.6"
-      NP_BUILD_DEP: "numpy==1.12"
-      NP_TEST_DEP: "numpy==1.12"
-    - PYTHON: C:\Python37-x64
-      PYTHON_ARCH: "64"
-      PYTHON_VERSION: "3.7"
-      NP_BUILD_DEP: "numpy==1.14.5"
-      NP_TEST_DEP: "numpy==1.14.5"
 
 init:
   - "ECHO \"%APPVEYOR_SCHEDULED_BUILD%\""

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 env:
     global:
-        - BUILD_COMMIT=v0.11.1
+        - BUILD_COMMIT=v0.12.0
         - REPO_DIR=pyFFTW
         # pip dependencies to _build_ your project
-        - NP_BUILD_DEP="numpy==1.10.4"
+        - NP_BUILD_DEP="numpy==1.13.3"
         - CYTHON_BUILD_DEP="Cython"
         # pip dependencies to _test_ your project.  Include any dependencies
         # that you need, that are also specified in BUILD_DEPENDS, this will be
         # a separate install.
-        - NP_TEST_DEP="numpy==1.10.4"
+        - NP_TEST_DEP="numpy==1.13.3"
         - PLAT=x86_64
         - UNICODE_WIDTH=32
         - MANYLINUX_URL="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
@@ -21,7 +21,7 @@ language: generic
 sudo: required
 dist: trusty
 services: docker
-osx_image: xcode6.4
+osx_image: xcode10.1
 
 matrix:
   include:
@@ -31,35 +31,6 @@ matrix:
       env:
         - MB_PYTHON_VERSION=2.7
         - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP=numpy==1.14.5
-        - NP_TEST_DEP=numpy==1.14.5
-    - os: osx
-      env:
-        - MB_PYTHON_VERSION=2.7
-    - os: osx
-      env:
-        - MB_PYTHON_VERSION=3.5
-    - os: osx
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
-    - os: osx
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP=numpy==1.14.5
-        - NP_TEST_DEP=numpy==1.14.5
 
 before_install:
     - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP"


### PR DESCRIPTION
In #30, I had dropped Python 2.7 which is the plan going forward for future releases.

This PR is just to build wheels for 2.7 on the 0.12 release, but should not be merged.