### PR TITLE
restore OS X build case on Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
       env:
         - MB_PYTHON_VERSION=2.7
         - UNICODE_WIDTH=16
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=2.7
 
 before_install:
     - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP"


### PR DESCRIPTION
This PR restores the OS X build for Python 2.7 that was accidentally removed in #32.